### PR TITLE
Wait for confirms or raise publish error

### DIFF
--- a/lib/hutch/broker.rb
+++ b/lib/hutch/broker.rb
@@ -292,6 +292,7 @@ module Hutch
 
     def ensure_connection!(routing_key, message)
       raise_publish_error('no connection to broker', routing_key, message) unless @connection
+      raise_publish_error('connection is closed', routing_key, message) unless @connection.open?
     end
 
     def channel_broker

--- a/lib/hutch/cli.rb
+++ b/lib/hutch/cli.rb
@@ -93,7 +93,6 @@ module Hutch
       :error
     end
 
-    # rubocop:disable Metrics/AbcSize
     def parse_options(args = ARGV)
       OptionParser.new do |opts|
         opts.banner = 'usage: hutch [options]'
@@ -210,7 +209,6 @@ module Hutch
         end
       end.parse!(args)
     end
-    # rubocop:enable Metrics/AbcSize
 
     def write_pid
       pidfile = File.expand_path(Hutch::Config.pidfile)

--- a/spec/hutch/broker_spec.rb
+++ b/spec/hutch/broker_spec.rb
@@ -401,12 +401,14 @@ describe Hutch::Broker do
         it 'waits for confirms on the channel', adapter: :bunny do
           expect_any_instance_of(Bunny::Channel)
             .to receive(:wait_for_confirms)
+            .and_return(true)
           broker.publish('test.key', 'message')
         end
 
         it 'waits for confirms on the channel', adapter: :march_hare do
           expect_any_instance_of(MarchHare::Channel)
             .to receive(:wait_for_confirms)
+            .and_return(true)
           broker.publish('test.key', 'message')
         end
       end
@@ -539,12 +541,14 @@ describe Hutch::Broker do
           it 'waits for confirms on the channel', adapter: :bunny do
             expect_any_instance_of(Bunny::Channel)
               .to receive(:wait_for_confirms)
+              .and_return(true)
             broker.publish_wait('test.key', 'message')
           end
 
           it 'waits for confirms on the channel', adapter: :march_hare do
             expect_any_instance_of(MarchHare::Channel)
               .to receive(:wait_for_confirms)
+              .and_return(true)
             broker.publish_wait('test.key', 'message')
           end
         end


### PR DESCRIPTION
If wait for confirms returns false, raise error. This indicates a message has been nacked.