### PR TITLE
Setup CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,6 @@ jobs:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
         
-      # Database setup
-      - run: bundle exec rake db:create
-      - run: bundle exec rake db:schema:load
-
       # run tests!
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.3.4
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: rabbitmq:3.6.11
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        
+      # Database setup
+      - run: bundle exec rake db:create
+      - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+            
+            bundle exec rspec --format progress \
+                              --format RspecJunitFormatter \
+                              --out /tmp/test-results/rspec.xml \
+                              --format progress \
+                              "${TEST_FILES}"
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
                               --format RspecJunitFormatter \
                               --out /tmp/test-results/rspec.xml \
                               --format progress \
-                              "${TEST_FILES}"
+                              ${TEST_FILES}
 
       # collect reports
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,22 +14,10 @@ jobs:
     steps:
       - checkout
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
       - run:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
       # Wait for RabbitMQ to be available
       - run:
@@ -43,7 +31,8 @@ jobs:
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
             
-            bundle exec rspec --format progress \
+            bundle exec rspec --profile 10 \
+                              --format progress \
                               --format RspecJunitFormatter \
                               --out /tmp/test-results/rspec.xml \
                               --format progress \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ jobs:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      # Wait for RabbitMQ to be available
+      - run:
+          name: wait for rabbitmq
+          command: while ! ss -lnt | grep ":5672\>" ; do sleep 0.5 ; done
         
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: rabbitmq:3.6.11
+      - image: rabbitmq:3.6.11-management
 
     working_directory: ~/repo
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem 'newrelic_rpm'
   gem 'airbrake'
   gem 'rb-inotify', '~> 0.9', require: false
+  gem 'rspec_junit_formatter', '~> 0.3.0'
 end
 
 group :development, :darwin do


### PR DESCRIPTION
CircleCI 2.0 uses docker containers to run builds quickly and in a consistent way. This allows us to try builds locally and specify a particular version of rabbitmq and ruby to build against.

* Chosen RabbitMQ 3.6.11 as it is current and working fine on local setup even if it is ahead of our production setup
* Chosen Ruby 2.3.4 as it is the closest available to the version we run (2.3.1).