### PR TITLE
Revert "Revert handle acks and nacks on main thread"

### DIFF
--- a/lib/hutch/worker.rb
+++ b/lib/hutch/worker.rb
@@ -23,6 +23,8 @@ module Hutch
       # Set up signal handlers for graceful shutdown
       register_signal_handlers
 
+      register_action_handlers
+
       setup_queues
 
       main_loop
@@ -33,11 +35,17 @@ module Hutch
         # Binds shutdown listener to notify main thread if channel was closed
         bind_shutdown_handler
 
-        handle_signals until shutdown_not_called?(0.1)
+        until shutdown_not_called?(0.1)
+          handle_actions
+          handle_signals
+        end
       else
         # Take a break from Thread#join every 0.1 seconds to check if we've
-        # been sent any signals
-        handle_signals until @broker.wait_on_threads(0.1)
+        # been sent any actions or signals
+        until @broker.wait_on_threads(0.1)
+          handle_actions
+          handle_signals
+        end
       end
     end
 
@@ -60,6 +68,26 @@ module Hutch
       if signal
         logger.info "caught sig#{signal.downcase}, stopping hutch..."
         stop
+      end
+    end
+
+    # Register action queue for acknowledging messages in main thread
+    # Messages consumed come from main thread so acks and nacks need to use the
+    # same channel
+    def register_action_handlers
+      Thread.main[:action_queue] = Queue.new
+    end
+
+    # Handle all pending message acknowledgement actions
+    def handle_actions
+      until Thread.main[:action_queue].empty?
+        action, delivery_info, properties, ex = Thread.main[:action_queue].pop
+        case action
+        when :ack
+          @broker.ack(delivery_info.delivery_tag)
+        when :nack
+          acknowledge_error(delivery_info, properties, @broker, ex)
+        end
       end
     end
 
@@ -120,9 +148,9 @@ module Hutch
       consumer_instance.broker = @broker
       consumer_instance.delivery_info = delivery_info
       with_tracing(consumer_instance).handle(message)
-      @broker.ack(delivery_info.delivery_tag)
+      Thread.main[:action_queue] << [:ack, delivery_info, properties, nil]
     rescue => ex
-      acknowledge_error(delivery_info, properties, @broker, ex)
+      Thread.main[:action_queue] << [:nack, delivery_info, properties, ex]
       handle_error(properties.message_id, payload, consumer, ex)
     end
 

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -52,12 +52,15 @@ describe Hutch::Worker do
     let(:properties) { double('Properties', message_id: nil, content_type: 'application/json') }
     let(:handle_message) do
       worker.handle_message(consumer, delivery_info, properties, payload)
+      worker.handle_actions
     end
     before { allow(consumer).to receive_messages(new: consumer_instance) }
     before { allow(broker).to receive(:ack) }
     before { allow(broker).to receive(:nack) }
     before { allow(consumer_instance).to receive(:broker=) }
     before { allow(consumer_instance).to receive(:delivery_info=) }
+    before { worker.register_action_handlers }
+    after { Thread.main[:action_queue].clear }
 
     context 'when the consumer processes without an exception' do
       before { allow(consumer_instance).to receive(:process) }

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -91,7 +91,7 @@ describe Hutch::Worker do
         expect(broker).to_not receive(:nack)
         expect(broker).to receive(:requeue)
 
-        worker.handle_message(consumer, delivery_info, properties, payload)
+        handle_message
       end
     end
 


### PR DESCRIPTION
Reverts Fatsoma/hutch#17

Hutch listens for messages on a channel in master thread and calls consumers in a work pool thread. This means passing acknowledgements on the channel on master thread was correct after all.

Fixes issue with hutch not processing messages