### PR TITLE
Hutch will log and notify on channel error

### DIFF
--- a/lib/hutch/channel_broker.rb
+++ b/lib/hutch/channel_broker.rb
@@ -80,7 +80,7 @@ module Hutch
             error_class: 'Hutch::ChannelBroker::OnError',
             error_message: error_message,
             context: context
-          )
+          ) if defined?(::Honeybadger)
         end
       end
     end

--- a/lib/hutch/channel_broker.rb
+++ b/lib/hutch/channel_broker.rb
@@ -69,7 +69,7 @@ module Hutch
           logger.error "Channel error [channel=#{channel.inspect}, method=#{method.inspect}, active=#{active}]"
 
           context = {method: method.inspect}
-          if method && method.is_a?(AMQ::Protocol::Channel::Close)
+          if method.is_a?(AMQ::Protocol::Channel::Close)
             error_message = method.reply_text
             context[:reply_code] = method.reply_code
           else

--- a/lib/hutch/channel_broker.rb
+++ b/lib/hutch/channel_broker.rb
@@ -63,6 +63,25 @@ module Hutch
           logger.info 'enabling publisher confirms'
           ch.confirm_select
         end
+
+        # on_error handler logs and notifies any unhandled channel errors
+        ch.on_error do |channel, method|
+          logger.error "Channel error [channel=#{channel.inspect}, method=#{method.inspect}, active=#{active}]"
+
+          context = {method: method.inspect}
+          if method && method.is_a?(AMQ::Protocol::Channel::Close)
+            error_message = method.reply_text
+            context[:reply_code] = method.reply_code
+          else
+            error_message = 'Channel error'
+          end
+
+          ::Honeybadger.notify(
+            error_class: 'Hutch::ChannelBroker::OnError',
+            error_message: error_message,
+            context: context
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Ticket: https://fatsoma.atlassian.net/browse/ENG-549

Our Ruby Hutch consumer ECS tasks occasionally lose their binding to RabbitMQ - this means messages don’t get processed and queues back up.

See: https://github.com/ruby-amqp/hutch/issues/364

Bunny doesn't raise the underlying errors. The `on_error` log/Honeybadger hook here is an attempt to improve visibility. A handler for the bunny `uncaught_exception_handler` is not added here as our queue gem handles the same exceptions.

Example consumer error:

<br><img width="1718" height="278" alt="Screenshot 2025-09-18 at 15 03 35" src="https://github.com/user-attachments/assets/f332b8ef-09f4-4ef5-b85f-8cc2586d6cee" /><br>

Example Honeybadger error: 

<br><img width="1718" height="558" alt="Screenshot 2025-09-18 at 15 04 03" src="https://github.com/user-attachments/assets/888822d0-c675-45ee-a07a-39dd77a04790" /><br>


This is also a potential place for us to either:
- Kill the process and let ECS handle the dead task
- Re-establish the bindings

E.g.
```ruby
if method &&
  method.is_a?(AMQ::Protocol::Channel::Close) &&
  method.reply_code == 406 &&
  method.reply_text =~ /delivery acknowledgement on channel \d+ timed out/
logger.error "Delivery acknowledgement timeout error encountered, shutting down [#{@config[:graceful_exit_timeout]}]"
sleep @config[:graceful_exit_timeout]
exit 1
end
```