### PR TITLE
The waiter will drain the action queue on main thread wake

### DIFF
--- a/lib/hutch/waiter.rb
+++ b/lib/hutch/waiter.rb
@@ -42,7 +42,7 @@ module Hutch
 
     def push_action(action, delivery_info, properties, ex)
       Thread.main[:action_queue] << [action, delivery_info, properties, ex]
-      action_write.write("#{delivery_info.delivery_tag}\n")
+      action_write.write("x") # Single byte notification
     end
 
     # return true to continue processing
@@ -68,16 +68,13 @@ module Hutch
       false
     end
 
-    # return true to continue processing
-    def handle_action(_delivery_tag)
+    def handle_action
       action, delivery_info, properties, ex = Thread.main[:action_queue].pop
-      # TODO: check delivery_tag ??
       case action
       when :ack then broker.ack(delivery_info.delivery_tag)
       when :nack then acknowledge_error(delivery_info, properties, ex)
       else raise "Assertion failed - unhandled action: #{action.inspect}"
       end
-      true
     end
 
     def acknowledge_error(delivery_info, properties, ex)
@@ -96,8 +93,25 @@ module Hutch
         sig = sig_read.gets.chomp
         handle_signal(sig)
       when action_read
-        delivery_tag = action_read.gets.chomp
-        handle_action(delivery_tag)
+        count = 0
+        batch_size = 5
+
+        # Process a batch of up to 5 messages
+        while count < batch_size
+          # Try to read one notification
+          begin
+            action_read.read_nonblock(1) # Read just one byte
+          rescue IO::WaitReadable
+            break # No more notifications in pipe
+          end
+
+          # Process the corresponding action
+          break if Thread.main[:action_queue].empty?
+          handle_action
+          count += 1
+        end
+
+        true # return true to continue processing
       end
     end
 

--- a/spec/hutch/worker_spec.rb
+++ b/spec/hutch/worker_spec.rb
@@ -73,7 +73,7 @@ describe Hutch::Worker do
   describe '#handle_message' do
     subject do
       worker.handle_message(consumer, delivery_info, properties, payload)
-      waiter.handle_action(delivery_info.delivery_tag)
+      waiter.handle_action
     end
     let(:payload) { '{}' }
     let(:consumer_instance) { double('Consumer instance') }


### PR DESCRIPTION
Ticket: https://fatsoma.atlassian.net/browse/ENG-549

This is part of an ongoing investigation into delivery acknowledgement timeout errors that we are intermittently experiencing in production (particularly in the ticket service). This change modifies the waiter, so that when the main thread wakes up it drains the action queue of n messages, rather than processing a single ack/nack at a time. The reasoning is that the main thread might not be keeping up with the work pushed by consumer threads, leading to acks not being sent within the 2 hour window.